### PR TITLE
Feature/backend moderate analyse

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,9 +1,12 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Post, Req, Body } from '@nestjs/common';
 import { AdminService } from './admin.service';
+import { Moderation } from 'src/article/article.schema';
+import { ModerateArticleDto } from './types/moderate-article.dto';
+import { AnalyseArticleDto } from './types/analyse-article.dto';
 
 @Controller()
 export class AdminController {
-  constructor(private readonly adminService: AdminService) {}
+  constructor(private readonly adminService: AdminService) { }
 
   @Get('admin')
   getDefault(): string {
@@ -18,5 +21,16 @@ export class AdminController {
   @Get('admin/queue/analyst')
   async getAnalystQueue() {
     return await this.adminService.getAnalystQueue();
+  }
+
+  @Post('admin/moderate')
+  async moderateArticle(@Body() body: ModerateArticleDto) {
+    // console.log(body);
+    return await this.adminService.moderateArticle(body);
+  }
+
+  @Post('admin/analyse')
+  async analyseArticle(@Body() body: AnalyseArticleDto) {
+    return await this.adminService.analyseArticle(body)
   }
 }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -4,6 +4,7 @@ import { ArticleModule } from '../article/article.module';
 import { Article, ArticleSchema } from '../article/article.schema';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
+import { NotificationModule } from 'src/notification/notification.module';
 
 @Module({
   imports: [
@@ -14,9 +15,10 @@ import { AdminService } from './admin.service';
       },
     ]),
     ArticleModule,
+    NotificationModule,
   ],
   controllers: [AdminController],
   providers: [AdminService],
   exports: [AdminService],
 })
-export class AdminModule {}
+export class AdminModule { }

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -3,6 +3,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Model } from 'mongoose';
 import { Article } from '../article/article.schema';
 import { AdminService } from './admin.service';
+import { ArticleService } from '../article/article.service';
+import { NotificationService } from '../notification/notification.service';
+import { AdminNotification } from '../notification/admin-notification.schema';
+import { UserNotification } from '../notification/user-notification.schema';
+
 
 const mockAdminController = {
   getAnalystQueue: jest.fn(),
@@ -11,22 +16,39 @@ const mockAdminController = {
 
 describe('AdminService', () => {
   let adminService: AdminService;
-
+  let articleService: ArticleService;
+  let notificationService: NotificationService;
   let articleModel: Model<Article>;
+  let adminNotificationModel: Model<AdminNotification>
+  let userNotificationModel: Model<UserNotification>
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminService,
+        ArticleService,
+        NotificationService,
         {
           provide: getModelToken(Article.name),
           useValue: mockAdminController,
         },
+        {
+          provide: getModelToken(AdminNotification.name),
+          useValue: adminNotificationModel
+        },
+        {
+          provide: getModelToken(UserNotification.name),
+          useValue: userNotificationModel
+        }
       ],
     }).compile();
 
     adminService = module.get<AdminService>(AdminService);
+    articleService = module.get<ArticleService>(ArticleService);
+    notificationService = module.get<NotificationService>(NotificationService);
     articleModel = module.get<Model<Article>>(getModelToken(Article.name));
+    adminNotificationModel = module.get<Model<AdminNotification>>(getModelToken(AdminNotification.name));
+    userNotificationModel = module.get<Model<UserNotification>>(getModelToken(UserNotification.name));
   });
 
   it('should be defined', () => {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -7,6 +7,7 @@ import { NotificationService } from '../notification/notification.service';
 import { CreateUserNotificationDto } from '../notification/dto/create-user-notification.dto';
 import { ArticleService } from '../article/article.service';
 import { AnalyseArticleDto } from './types/analyse-article.dto';
+import { CreateAdminNotifcationDto } from 'src/notification/dto/create-admin-notification.dto';
 
 @Injectable()
 export class AdminService {
@@ -26,24 +27,39 @@ export class AdminService {
     return await this.articleModel.find({
       'moderation.moderated': true,
       'moderation.moderation_passed': true,
-      'analysis.analyzed': false,
+      'analysis.analysed': false,
     });
   }
 
   async moderateArticle({ articleId, moderationDetails }: ModerateArticleDto): Promise<any> {
     try {
       const updatedResult = await this.articleService.moderateArticle(articleId, moderationDetails);
+
+      if(moderationDetails.moderation_passed) {
+        const analystNotification: CreateAdminNotifcationDto = {
+          user_id: updatedResult.submitterId,
+          role: 'analyst',
+          article_id: articleId,
+          article_title: updatedResult.title,
+          title: 'New article needs analysis',
+          message: 'View to get assigned',
+          assigned: false,
+          assignee_id: '',
+        }
+        this.notificationService.sendNotification(analystNotification);
+      }
+
       const userNotification: CreateUserNotificationDto = {
         user_id: updatedResult.submitterId.toString(),
         article_id: "123",
         article_title: "Rubbish",
         title: `Your article has been ${moderationDetails.status}`,
-        message: `${moderationDetails.status == 'approved' ? "Congratulations, your article has been approved and now pending analysis." : "Rejected lmao"}`,
+        message: `${moderationDetails.status == 'approved' ? "Congratulations, your article has been approved and now pending analysis." : "Your article has been rejected"}`,
         read: false
       }
       this.notificationService.sendNotification(userNotification);
-      return { message: "Successfuly moderated article" };
 
+      return { message: "Successfully moderated article" };
     } catch (error) {
       return { message: "Error in moderating article, try again or try later" }
     }
@@ -57,14 +73,14 @@ export class AdminService {
         article_id: "123",
         article_title: "Rubbish",
         title: `Your article has been ${analysisDetails.status}`,
-        message: `${analysisDetails.status == 'completed' ? "Congratulations, your article has been analysed and is now visible" : "Rejected lmao"}`,
+        message: `${analysisDetails.status == 'completed' ? "Congratulations, your article has been analysed and is now visible" : "After further analysis your article has been rejected"}`,
         read: false
       }
       this.notificationService.sendNotification(userNotification);
-      return { message: "Successfuly moderated article" };
+      return { message: "Successfully analysed article" };
 
     } catch (error) {
-      return { message: "Error in moderating article, try again or try later" }
+      return { message: "Error in analsing article, try again or try later" }
     }
   }
 }

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -2,11 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Article } from '../article/article.schema';
+import { ModerateArticleDto } from './types/moderate-article.dto';
+import { NotificationService } from '../notification/notification.service';
+import { CreateUserNotificationDto } from '../notification/dto/create-user-notification.dto';
+import { ArticleService } from '../article/article.service';
+import { AnalyseArticleDto } from './types/analyse-article.dto';
 
 @Injectable()
 export class AdminService {
   constructor(
     @InjectModel(Article.name) private articleModel: Model<Article>,
+    private readonly notificationService: NotificationService,
+    private readonly articleService: ArticleService
   ) { }
 
   async getModeratorQueue(): Promise<any> {
@@ -21,5 +28,43 @@ export class AdminService {
       'moderation.moderation_passed': true,
       'analysis.analyzed': false,
     });
+  }
+
+  async moderateArticle({ articleId, moderationDetails }: ModerateArticleDto): Promise<any> {
+    try {
+      const updatedResult = await this.articleService.moderateArticle(articleId, moderationDetails);
+      const userNotification: CreateUserNotificationDto = {
+        user_id: updatedResult.submitterId.toString(),
+        article_id: "123",
+        article_title: "Rubbish",
+        title: `Your article has been ${moderationDetails.status}`,
+        message: `${moderationDetails.status == 'approved' ? "Congratulations, your article has been approved and now pending analysis." : "Rejected lmao"}`,
+        read: false
+      }
+      this.notificationService.sendNotification(userNotification);
+      return { message: "Successfuly moderated article" };
+
+    } catch (error) {
+      return { message: "Error in moderating article, try again or try later" }
+    }
+  }
+
+  async analyseArticle({ articleId, analysisDetails }: AnalyseArticleDto): Promise<any> {
+    try {
+      const updatedResult = await this.articleService.analyseArticle(articleId, analysisDetails);
+      const userNotification: CreateUserNotificationDto = {
+        user_id: updatedResult.submitterId.toString(),
+        article_id: "123",
+        article_title: "Rubbish",
+        title: `Your article has been ${analysisDetails.status}`,
+        message: `${analysisDetails.status == 'completed' ? "Congratulations, your article has been analysed and is now visible" : "Rejected lmao"}`,
+        read: false
+      }
+      this.notificationService.sendNotification(userNotification);
+      return { message: "Successfuly moderated article" };
+
+    } catch (error) {
+      return { message: "Error in moderating article, try again or try later" }
+    }
   }
 }

--- a/backend/src/admin/types/analyse-article.dto.ts
+++ b/backend/src/admin/types/analyse-article.dto.ts
@@ -1,0 +1,6 @@
+import { UpdateAnalysisDto } from "src/article/dto/update-analysis.dto";
+
+export class AnalyseArticleDto {
+    articleId: string;
+    analysisDetails: UpdateAnalysisDto
+}

--- a/backend/src/admin/types/moderate-article.dto.ts
+++ b/backend/src/admin/types/moderate-article.dto.ts
@@ -1,0 +1,6 @@
+import { UpdateModerationDto } from "src/article/dto/update-moderation.dto";
+
+export interface ModerateArticleDto {
+    articleId: string;
+    moderationDetails: UpdateModerationDto
+}

--- a/backend/src/article/article.service.spec.ts
+++ b/backend/src/article/article.service.spec.ts
@@ -128,7 +128,7 @@ describe('ArticleService', () => {
         });
       const result = await service.createArticle('123', createArticleDto);
 
-      console.log(result);
+      // console.log(result);
       // expect(articleModel.create).toHaveBeenCalledWith("123", createArticleDto);
       expect(result).toEqual(mockArticle);
     });

--- a/backend/src/article/article.service.ts
+++ b/backend/src/article/article.service.ts
@@ -8,6 +8,8 @@ import { Article, Rating } from './article.schema';
 import { CreateArticleDto } from './dto/create-article.dto';
 import { RatingDto } from './dto/rating.dto';
 import { UpdateArticleDto } from './dto/update-article.dto';
+import { UpdateModerationDto } from './dto/update-moderation.dto';
+import { UpdateAnalysisDto } from './dto/update-analysis.dto';
 
 @Injectable()
 export class ArticleService {
@@ -42,6 +44,30 @@ export class ArticleService {
     }
   }
 
+  async moderateArticle(articleId: string, moderationDetails: UpdateModerationDto): Promise<Article> {
+    try {
+      moderationDetails.moderatedDate = new Date();
+      const updatedModerationDetails: UpdateModerationDto = moderationDetails;
+      await this.articleModel.findByIdAndUpdate(articleId, { $set: updatedModerationDetails });
+      const updatedResult = this.articleModel.findById(articleId);
+      return updatedResult;
+    } catch (error) {
+      throw new BadRequestException("Failed to update moderation details. " + error);
+    }
+  }
+
+  async analyseArticle(articleId: string, analysisDetails: UpdateAnalysisDto): Promise<Article> {
+    try {
+      analysisDetails.analysisDate = new Date();
+      const updatedAnalysisDetails: UpdateAnalysisDto = analysisDetails;
+      await this.articleModel.findByIdAndUpdate(articleId, { $set: updatedAnalysisDetails });
+      const updatedResult = this.articleModel.findById(articleId);
+      return updatedResult;
+    } catch (error) {
+      throw new BadRequestException("Failed to update analysis details. " + error);
+    }
+  }
+
   async createArticle(
     uid: string = 'no user',
     createArticleDto: CreateArticleDto,
@@ -59,7 +85,7 @@ export class ArticleService {
           comments: ""
         },
         analysis: {
-          analyserId: "",
+          analystId: "",
           analysed: false,
           status: "not analysed",
           summary: "",

--- a/backend/src/article/article.service.ts
+++ b/backend/src/article/article.service.ts
@@ -48,9 +48,9 @@ export class ArticleService {
     try {
       moderationDetails.moderatedDate = new Date();
       const updatedModerationDetails: UpdateModerationDto = moderationDetails;
-      await this.articleModel.findByIdAndUpdate(articleId, { $set: updatedModerationDetails });
-      const updatedResult = this.articleModel.findById(articleId);
-      return updatedResult;
+      const updatedArticle = await this.articleModel.findByIdAndUpdate(articleId, { $set: {"moderation": updatedModerationDetails }}, {new: true});
+
+      return updatedArticle;
     } catch (error) {
       throw new BadRequestException("Failed to update moderation details. " + error);
     }
@@ -60,9 +60,9 @@ export class ArticleService {
     try {
       analysisDetails.analysisDate = new Date();
       const updatedAnalysisDetails: UpdateAnalysisDto = analysisDetails;
-      await this.articleModel.findByIdAndUpdate(articleId, { $set: updatedAnalysisDetails });
-      const updatedResult = this.articleModel.findById(articleId);
-      return updatedResult;
+      const updatedArticle = await this.articleModel.findByIdAndUpdate(articleId, { $set: {"analysis": updatedAnalysisDetails }}, {new: true});
+      
+      return updatedArticle;
     } catch (error) {
       throw new BadRequestException("Failed to update analysis details. " + error);
     }
@@ -106,18 +106,9 @@ export class ArticleService {
         assigned: false,
         assignee_id: '',
       };
-      const temp2: CreateUserNotificationDto = {
-        user_id: uid,
-        article_id: createResult._id.toString(),
-        article_title: createResult.title,
-        title: 'Article Approved',
-        message: 'Your submitted article has been approved.',
-        read: false,
-      };
-
+    
       if (createResult) {
         await this.notificationService.sendNotification(adminNotification);
-        await this.notificationService.sendNotification(temp2);
       }
       return createResult;
     } catch (error) {

--- a/backend/src/article/dto/update-analysis.dto.ts
+++ b/backend/src/article/dto/update-analysis.dto.ts
@@ -1,11 +1,11 @@
 import { User } from '../../user/user.schema';
 
 export class UpdateAnalysisDto {
-  analysedBy: User;
+  analystId: String;
   analysed: boolean;
-  status: boolean;
+  status: string;
   summary: string;
   keyFindings: string[];
   methodology: string;
-  analysedDate: Date;
+  analysisDate: Date;
 }

--- a/backend/src/article/dto/update-moderation.dto.ts
+++ b/backend/src/article/dto/update-moderation.dto.ts
@@ -1,9 +1,8 @@
-import { User } from '../../user/user.schema';
-
 export class UpdateModerationDto {
-  moderatedBy: User;
+  moderatorId: String;
   moderated: boolean;
-  status: boolean;
+  moderation_passed: boolean;
+  status: string;
   comments: string;
   moderatedDate: Date;
 }

--- a/backend/src/notification/notification.service.ts
+++ b/backend/src/notification/notification.service.ts
@@ -55,7 +55,7 @@ export class NotificationService {
     }
 
     async assignAdminNotification(uid: string, {notification_id}: UpdateUserNotificationDto): Promise<any> {
-        return await this.userNotiModel.findByIdAndUpdate({
+        return await this.adminNotiModel.findByIdAndUpdate({
                 _id: new mongoose.Types.ObjectId(notification_id),
                 user_id: uid
             },

--- a/frontend/src/components/notification/notification-dropdown.tsx
+++ b/frontend/src/components/notification/notification-dropdown.tsx
@@ -91,7 +91,7 @@ const NotificationDropdown = ({user, token}: UserProps) => {
                             <h4 className="font-medium leading-none">Article Queue</h4>
                             {queueNotifications.length != 0 ? queueNotifications.map((notification, index) => (
                                 <div key={index}>
-                                    <NotificationItem notification={notification} />
+                                    <NotificationItem notification={notification} token={token}/>
                                 <Separator />
                             </div>
                             )): (
@@ -113,7 +113,7 @@ const NotificationDropdown = ({user, token}: UserProps) => {
                         <h4 className="font-medium leading-none">Notifications</h4>
                         {userNotifications.length != 0 ? userNotifications.map((notification, index) => (
                             <div key={index}>
-                                <NotificationItem notification={notification} />
+                                <NotificationItem notification={notification} token={token}/>
                             <Separator />
                          </div>
                         )): (

--- a/frontend/src/components/notification/notification-item.tsx
+++ b/frontend/src/components/notification/notification-item.tsx
@@ -2,14 +2,16 @@ import { AdminNotifcation } from "@/types/notification/admin-notification";
 import { UserNotification } from "@/types/notification/user-notification";
 import { useRouter } from "next/navigation";
 import { Button } from "../ui/button";
+import { User } from "@/types";
 
 interface Props {
     notification: AdminNotifcation | UserNotification
+    token: string
 }
 
 
 
-const NotificationItem: React.FC<Props> = ({ notification }) => {
+const NotificationItem = ({ notification, token}:Props) => {
 
     const router = useRouter();
 
@@ -17,11 +19,22 @@ const NotificationItem: React.FC<Props> = ({ notification }) => {
         if ("role" in notification) {
             // Change to moderate view afterwards
             router.push(`/articles/${notification.article_id}`);
+            // Updates notification to be assigned
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/notifications/assign`, {
+                method: "PUT",
+                headers: {
+                    "Authorization": "Bearer " + token,
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    "notification_id": notification._id
+                })
+            })
         } else {
             let temp = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/notifications/read`, {
                 method: "PUT",
                 headers: {
-                    "Authorization": "Bearer " + localStorage.getItem("token"),
+                    "Authorization": "Bearer " + token,
                     "Content-Type": "application/json"
                 },
                 body: JSON.stringify({

--- a/frontend/src/components/notification/notification-item.tsx
+++ b/frontend/src/components/notification/notification-item.tsx
@@ -14,8 +14,7 @@ const NotificationItem: React.FC<Props> = ({ notification }) => {
     const router = useRouter();
 
     const viewArticle = async () => {
-        console.log("role" in notification ? "ADMIN NOTI" : "USER NOTI")
-        if("role" in notification) {
+        if ("role" in notification) {
             // Change to moderate view afterwards
             router.push(`/articles/${notification.article_id}`);
         } else {
@@ -34,7 +33,7 @@ const NotificationItem: React.FC<Props> = ({ notification }) => {
     }
 
     return (
-        <div className="flex items-center p-1 justify-between">
+        <div className="flex items-center p-1 justify-between max-w-md">
             <div className="p-1 grid grid-cols-[25px_1fr] items-start pb-4 last:mb-0 last:pb-0 pr-10">
                 <span className="flex h-2 w-2 translate-y-1.5 rounded-full bg-blue-500" />
                 <div className="grid gap-1">


### PR DESCRIPTION
**Changes**
- Add `/admin/moderate` and `/admin/analyse` endpoints
- Sends user notification when article is moderated or analyzed

**Misc**
- Updated unit test


**Moderate Endpoint**
- Takes in a ModerateArticleDto
```JS
ModerateArticleDto {
    articleId: string;
    moderationDetails: {
        moderatorId: string;
        moderated: boolean;
        moderation_passed: boolean;
        status: string;
        comments: string;
        moderationDate: Date;
    }
}
````

**Analysis Endpoint**
- Takes in a AnalyseArticleDto
```JS
AnalyseArticleDto {
    articleId: string;
    analysisDetails: {
        analystId: string;
        analysed: boolean;
        status: string;
        summary: string;
        keyFindings: string[];
        methodology: string;
        analysisDate: Date;
    }
}
```

**Notes**
- There is still no auth in the admin endpoint, hopefully I can get RBAC set up and running otherwise using basic authgard should suffice for now